### PR TITLE
Move Citizens from softdepend to depend

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,8 @@ main: me.mattmoreira.citizenscmd.CitizensCMD
 version: ${project.version}
 name: CitizensCMD
 author: Mateus Moreira
-softdepend: [Citizens, PlaceholderAPI, Vault]
+depend: Citizens
+softdepend: [PlaceholderAPI, Vault]
 api-version: 1.13
 
 commands:


### PR DESCRIPTION
Could fix some issues where the plugin loads before citizens does 
See https://github.com/ipsk/CitizensCMD/issues/8